### PR TITLE
Fix/fix platformio board and dead links

### DIFF
--- a/examples/arduino/board/board_dynamic_config/README.md
+++ b/examples/arduino/board/board_dynamic_config/README.md
@@ -15,7 +15,7 @@ This example in *esp_panel_drivers_conf.h* enables all drivers, while the defaul
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
@@ -23,12 +23,12 @@ This example in *esp_panel_drivers_conf.h* enables all drivers, while the defaul
 
   - Unlike the [board_static_config](../board_static_config) example, this example does not provide *esp_panel_board_supported_conf.h* and *esp_panel_board_custom_conf.h* files in the project directory.
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. **And to make sure the example works on all target boards, all drivers are enabled by default.**
-  - See [Configuring Guide](../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -46,7 +46,7 @@ This example in *esp_panel_drivers_conf.h* enables all drivers, while the defaul
 - Change the `PSRAM` option to `OPI PSRAM` if using `ESP32S3R8 + RGB LCD`, or `Enabled` if using `ESP32P4 + MIPI-DSI LCD`
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -103,4 +103,4 @@ Touch point(3): x 375, y 122, strength 37
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/board/board_static_config/README.md
+++ b/examples/arduino/board/board_static_config/README.md
@@ -13,7 +13,7 @@ This example demonstrates how to statically load the display screen settings of 
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
@@ -25,12 +25,12 @@ This example demonstrates how to statically load the display screen settings of 
     - **If using a custom board**, edit the *esp_panel_board_custom_conf.h* file and set `ESP_PANEL_BOARD_DEFAULT_USE_CUSTOM` to `1`. Then change other configurations as needed in the file
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed.
-  - see [Board Configuration Guide](../../../../docs/envs/use_with_arduino.md#configuration-guide) for more information
+  - see [Board Configuration Guide](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -43,7 +43,7 @@ This example demonstrates how to statically load the display screen settings of 
 - Change the `PSRAM` option to `OPI PSRAM` if using `ESP32S3R8 + RGB LCD`, or `Enabled` if using `ESP32P4 + MIPI-DSI LCD`
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -98,4 +98,4 @@ LCD FPS: 31
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/lcd/lcd_3wire_spi_rgb/README.md
+++ b/examples/arduino/drivers/lcd/lcd_3wire_spi_rgb/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to drive different model LCDs with `3-wire SPI + R
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -41,7 +41,7 @@ This example demonstrates how to drive different model LCDs with `3-wire SPI + R
 - Change the `PSRAM` option to `OPI PSRAM` if using `ESP32S3R8 + RGB LCD`, or `Enabled` if using `ESP32P4 + MIPI-DSI LCD`
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -92,4 +92,4 @@ LCD FPS: 98
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/lcd/lcd_mipi_dsi/README.md
+++ b/examples/arduino/drivers/lcd/lcd_mipi_dsi/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to drive different model LCDs with `MIPI-DSI` inte
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -41,7 +41,7 @@ This example demonstrates how to drive different model LCDs with `MIPI-DSI` inte
 - Change the `PSRAM` option to `OPI PSRAM` if using `ESP32S3R8 + RGB LCD`, or `Enabled` if using `ESP32P4 + MIPI-DSI LCD`
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -100,4 +100,4 @@ LCD FPS: 69
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/lcd/lcd_qspi/README.md
+++ b/examples/arduino/drivers/lcd/lcd_qspi/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to drive different model LCDs with `QSPI` interfac
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -40,7 +40,7 @@ This example demonstrates how to drive different model LCDs with `QSPI` interfac
 - Select the target board in the `Board` menu
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -86,4 +86,4 @@ IDLE loop
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/lcd/lcd_single_rgb/README.md
+++ b/examples/arduino/drivers/lcd/lcd_single_rgb/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to drive different model LCDs with `Single RGB` in
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -41,7 +41,7 @@ This example demonstrates how to drive different model LCDs with `Single RGB` in
 - Change the `PSRAM` option to `OPI PSRAM` if using `ESP32S3R8 + RGB LCD`, or `Enabled` if using `ESP32P4 + MIPI-DSI LCD`
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -87,4 +87,4 @@ LCD FPS: 31
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/lcd/lcd_spi/README.md
+++ b/examples/arduino/drivers/lcd/lcd_spi/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to drive different model LCDs with `SPI` interface
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -40,7 +40,7 @@ This example demonstrates how to drive different model LCDs with `SPI` interface
 - Select the target board in the `Board` menu
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -87,4 +87,4 @@ IDLE loop
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/touch/touch_i2c/README.md
+++ b/examples/arduino/drivers/touch/touch_i2c/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to drive different model touches with `I2C` interf
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -40,7 +40,7 @@ This example demonstrates how to drive different model touches with `I2C` interf
 - Select the target board in the `Board` menu
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -78,4 +78,4 @@ Touch point(0): x 72, y 76, strength 28
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/arduino/drivers/touch/touch_spi/README.md
+++ b/examples/arduino/drivers/touch/touch_spi/README.md
@@ -16,19 +16,19 @@ This example demonstrates how to develop different model touches with SPI interf
 
 - Install the following SDK and library dependencies:
 
-  - See [SDK & Dependencies](../../../../../docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../docs/envs/use_with_arduino.md#installing-libraries) sections for more information
+  - See [SDK & Dependencies](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#sdk--dependencies) and [Installing Libraries](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#installing-libraries) sections for more information
 
 ### Step 2. Configure the libraries
 
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_drivers_conf.h](./esp_panel_drivers_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring Guide](../../../../../docs/envs/use_with_arduino.md#configuration-guide) section for more information
+  - See [Configuring Guide](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) section for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 ### Step 3. Configure the example
 
@@ -40,7 +40,7 @@ This example demonstrates how to develop different model touches with SPI interf
 - Select the target board in the `Board` menu
 - Change the `USB CDC On Boot` option to `Enabled` if using `USB` port, or `Disabled` if using `UART` port. If this configuration differs from previous flashing, first enable `Erase All Flash Before Sketch Upload`, then it can be disabled after flashing.
 - Change other configurations as needed
-- see [Configuring Arduino IDE](../../../../../docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
+- see [Configuring Arduino IDE](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-arduino-ide) for more information
 
 ### Step 5. Compile and upload the project
 
@@ -76,4 +76,4 @@ Touch point(0): x 161, y 241, strength 1314
 
 ## Troubleshooting
 
-Please check the [FAQ](../../../../../docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.
+Please check the [FAQ](../../../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#faq) first to see if the same question exists. If not, please create a [Github Issue](https://github.com/esp-arduino-libs/ESP32_Display_Panel/issues). We will get back to you as soon as possible.

--- a/examples/platformio/lvgl_v8_port/README.md
+++ b/examples/platformio/lvgl_v8_port/README.md
@@ -14,17 +14,17 @@ This example demonstrates how to port `LVGL v8`. And for `RGB/MIPI-DSI` interfac
 - [Optional] `ESP32_Display_Panel`:
 
   - This example already has the [esp_panel_board_custom_conf.h](./src/esp_panel_board_custom_conf.h) and [esp_panel_drivers_conf.h](./src/esp_panel_drivers_conf.h) configuration files in the project directory. Edit these files as needed
-  - see [Board Configuration Guide](../../../docs/envs/use_with_arduino.md#configuration-guide) for more information
+  - see [Board Configuration Guide](../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuration-guide) for more information
 
 - [Optional] `esp-lib-utils` :
 
   - This example already has the [esp_utils_conf.h](./src/esp_utils_conf.h) configuration file in the project directory. Edit this file as needed
-  - See [Configuring esp-lib-utils](../../../docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
+  - See [Configuring esp-lib-utils](../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-esp-lib-utils) section for more information
 
 - [Optional] `lvgl` :
 
   - This example already has the [lv_conf.h](./src/lv_conf.h) configuration file which been modified with the recommended configurations in the project directory. Edit this file as needed
-  - See [Configuring LVGL](../../../docs/envs/use_with_arduino.md#configuring-lvgl) section for more information
+  - See [Configuring LVGL](../../../Libraries/ESP32_Display_Panel/docs/envs/use_with_arduino.md#configuring-lvgl) section for more information
 
 ### Step 2. Configure PlatformIO
 

--- a/examples/platformio/lvgl_v8_port/boards/BOARD_VIEWE_UEDX48480040E_WB_A.json
+++ b/examples/platformio/lvgl_v8_port/boards/BOARD_VIEWE_UEDX48480040E_WB_A.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "arduino":{
+    "arduino": {
       "ldscript": "esp32s3_out.ld",
       "partitions": "default_16MB.csv",
       "memory_type": "qio_opi"
@@ -35,7 +35,7 @@
     "arduino",
     "espidf"
   ],
-  "name": "Viewe UEDX80480070E-WB-A",
+  "name": "Viewe UEDX48480040E-WB-A",
   "upload": {
     "flash_size": "16MB",
     "maximum_ram_size": 327680,

--- a/examples/platformio/lvgl_v8_port/platformio.ini
+++ b/examples/platformio/lvgl_v8_port/platformio.ini
@@ -13,7 +13,7 @@ default_envs =
     ; BOARD_ESPRESSIF_ESP32_S3_LCD_EV_BOARD_2_V1_5
     ; BOARD_ESPRESSIF_ESP32_S3_USB_OTG
     ; BOARD_ESPRESSIF_ESP32_P4_FUNCTION_EV_BOARD
-    BOARD_VIEWE_UEDX80480070E_WB_A
+    BOARD_VIEWE_UEDX48480040E_WB_A
 
 ;
 ; Here are the global configurations used for all board envs
@@ -30,15 +30,15 @@ platform_packages =
 monitor_speed = 115200
 lib_deps =
 ; For production:
-    https://github.com/esp-arduino-libs/ESP32_Display_Panel.git
-    https://github.com/esp-arduino-libs/ESP32_IO_Expander.git#v1.1.0
-    https://github.com/esp-arduino-libs/esp-lib-utils.git#v0.2.0
-    https://github.com/lvgl/lvgl.git#v8.4.0
+    ; https://github.com/esp-arduino-libs/ESP32_Display_Panel.git
+    ; https://github.com/esp-arduino-libs/ESP32_IO_Expander.git#v1.1.0
+    ; https://github.com/esp-arduino-libs/esp-lib-utils.git#v0.2.0
+    ; https://github.com/lvgl/lvgl.git#v8.4.0
 ; For local development:
-    ; file://../../../../ESP32_Display_Panel
-    ; file://../../../../ESP32_IO_Expander
-    ; file://../../../../esp-lib-utils
-    ; file://../../../../lvgl
+    symlink://../../../Libraries/ESP32_Display_Panel
+    symlink://../../../Libraries/ESP32_IO_Expander
+    symlink://../../../Libraries/esp-lib-utils
+    symlink://../../../Libraries/lvgl-release-v8.4
 
 ;
 ; Here are the options that can be used in the board envs
@@ -166,10 +166,10 @@ build_flags =
 board = BOARD_ESPRESSIF_ESP32_P4_FUNCTION_EV_BOARD
 
 ; VIEWE boards:
-[env:BOARD_VIEWE_UEDX80480070E_WB_A]
+[env:BOARD_VIEWE_UEDX48480040E_WB_A]
 build_flags =
     ${common.build_flags}
     ${rgb_mipi_lcd.build_flags}
     -DESP_PANEL_BOARD_DEFAULT_USE_SUPPORTED=1
-    -DBOARD_VIEWE_UEDX80480070E_WB_A
-board = BOARD_VIEWE_UEDX80480070E_WB_A
+    -DBOARD_VIEWE_UEDX48480040E_WB_A
+board = BOARD_VIEWE_UEDX48480040E_WB_A


### PR DESCRIPTION
Hello!
When I tried to use the platformio example it did'nt work because the display model was incorrect, so I fixed it.
I also fixed broken links to the ESP32_Display_Panel library in the examples READMEs.